### PR TITLE
Fixed hyprland version check

### DIFF
--- a/src/wlr_layout_ui/screens.py
+++ b/src/wlr_layout_ui/screens.py
@@ -79,11 +79,12 @@ def load():
         displayInfo.clear()
 
     try:
-        v = json.loads(subprocess.getoutput("hyprctl -j version"))["tag"]
-        good_v = (37, 38, 39)
-        new_hyprland = any(v.startswith("v0.%d" % x) for x in good_v) or (
-            not v.startswith("v0.2") and not v.startswith("v0.1")
-        )
+        version = json.loads(subprocess.getoutput("hyprctl -j version"))["tag"]
+        version = version[1:].split(".")
+        major = int(version[0])
+        minor = int(version[1])
+        _patch = int(version[2])
+        new_hyprland = major == 0 and minor >= 37 or major > 0
     except (KeyError, json.JSONDecodeError):
         new_hyprland = False
 


### PR DESCRIPTION
The expression checking the hyprland version number returned True, if e.g. hyprland v0.35.0 or any v0.3x.0 smaller than v0.37.0 was used.
The hyprctl json format of these older versions is not compatible with the current parsing and wlr-randr should be used.

Reasoning:
The old "positiv check" (>=v0.37.0) was combined with a logical OR and the "negative check" for versions v0.1.0 and v0.2.0. So if either of this statements is True, the hole expression is true. Therefore e.g. hyprland v0.35.0 also gets True.

