### PR TITLE
Add wlrlui -m to automatically match profiles

### DIFF
--- a/src/wlr_layout_ui/__init__.py
+++ b/src/wlr_layout_ui/__init__.py
@@ -54,10 +54,10 @@ def main():
         elif sys.argv[1] == "-m":
             load()
             current_uids = set(di.uid for di in displayInfo)
-            for key in sorted(profiles.keys()):
+            for key in sorted(profiles):
                 prof_uids = {p["uid"] for p in profiles[key]}
                 # check that the two sets have the same elements
-                if len(prof_uids & current_uids) == len(current_uids):
+                if prof_uids == current_uids:
                     print(f"Matched profile {key}. Applying it...")
                     apply_profile(profiles[key])
                     sys.exit(0)
@@ -70,7 +70,7 @@ def main():
                 """With no options, launches the GUI
 Options:
              -l : list profiles
-             -m : find a profile that matches the current displays layout, and apply it. 
+             -m : find a profile that matches the currently plugged display set, and apply it. 
                   No-op if not found; will apply first in alphabetical order if multiple found.
  <profile name> : loads a profile
             """
@@ -83,7 +83,7 @@ Options:
                 print(f"No such profile: {sys.argv[1]}")
                 raise SystemExit(1)
             apply_profile(profile)
-        sys.exit(0)
+        return
     load()
     max_width = int(sum(max(screen.available, key=lambda mode: mode.width).width for screen in displayInfo) // UI_RATIO)
     max_height = int(sum(max(screen.available, key=lambda mode: mode.height).height for screen in displayInfo) // UI_RATIO)

--- a/src/wlr_layout_ui/__init__.py
+++ b/src/wlr_layout_ui/__init__.py
@@ -57,7 +57,7 @@ def main():
             for key in sorted(profiles.keys()):
                 prof_uids = {p["uid"] for p in profiles[key]}
                 # check that the two sets have the same elements
-                if len(prof_uids - current_uids) == 0:
+                if len(prof_uids & current_uids) == len(current_uids):
                     print(f"Matched profile {key}. Applying it...")
                     apply_profile(profiles[key])
                     sys.exit(0)

--- a/src/wlr_layout_ui/__init__.py
+++ b/src/wlr_layout_ui/__init__.py
@@ -17,6 +17,31 @@ except ImportError:
     pass
 
 
+def apply_profile(profile):
+    load()
+    p_by_id = {p["uid"]: p for p in profile}
+    rects = [
+        (
+            Rect(-i["x"], i["y"], i["height"], i["width"])
+            if i.get("transform", 0) in (1, 3, 5, 7)
+            else Rect(-i["x"], i["y"], i["width"], i["height"])
+        )
+        for i in profile
+    ]
+
+    for i, di in enumerate(displayInfo):
+        di.active = p_by_id[di.uid]["active"]
+        di.transform = p_by_id[di.uid].get("transform", 0)
+        di.scale = p_by_id[di.uid].get("scale", 1.0)
+        if di.transform in (1, 3, 5, 7):
+            rects[i].width, rects[i].height = rects[i].height, rects[i].width
+
+    cmd = make_command(displayInfo, rects, not LEGACY)
+    time.sleep(0.5)
+    if os.system(cmd):
+        print("Failed applying the layout")
+
+
 def main():
     if len(sys.argv) > 1:
         from .profiles import load_profiles
@@ -26,16 +51,30 @@ def main():
             print("")
             for p in profiles.keys():
                 print(f" - {p}")
+        elif sys.argv[1] == "-m":
+            load()
+            current_uids = set(di.uid for di in displayInfo)
+            for key in sorted(profiles.keys()):
+                prof_uids = {p["uid"] for p in profiles[key]}
+                # check that the two sets have the same elements
+                if len(prof_uids - current_uids) == 0:
+                    print(f"Matched profile {key}. Applying it...")
+                    apply_profile(profiles[key])
+                    sys.exit(0)
+            print(f"No profile found: {sys.argv[1]}")
+            sys.exit(1)
+
         elif sys.argv[1][0] == "-":
             load()
             print(
                 """With no options, launches the GUI
 Options:
              -l : list profiles
+             -m : find a profile that matches the current displays layout, and apply it. 
+                  No-op if not found; will apply first in alphabetical order if multiple found.
  <profile name> : loads a profile
             """
             )
-
         else:
             reload_pre_commands()
             try:
@@ -43,28 +82,7 @@ Options:
             except KeyError:
                 print("No such profile: %s" % sys.argv[1])
                 raise SystemExit(1)
-            load()
-            p_by_id = {p["uid"]: p for p in profile}
-            rects = [
-                (
-                    Rect(-i["x"], i["y"], i["height"], i["width"])
-                    if i.get("transform", 0) in (1, 3, 5, 7)
-                    else Rect(-i["x"], i["y"], i["width"], i["height"])
-                )
-                for i in profile
-            ]
-
-            for i, di in enumerate(displayInfo):
-                di.active = p_by_id[di.uid]["active"]
-                di.transform = p_by_id[di.uid].get("transform", 0)
-                di.scale = p_by_id[di.uid].get("scale", 1.0)
-                if di.transform in (1, 3, 5, 7):
-                    rects[i].width, rects[i].height = rects[i].height, rects[i].width
-
-            cmd = make_command(displayInfo, rects, not LEGACY)
-            time.sleep(0.5)
-            if os.system(cmd):
-                print("Failed applying the layout")
+            apply_profile(profile)
         sys.exit(0)
     load()
     max_width = int(


### PR DESCRIPTION
Hi,
This PR adds an `-m` option to `wlrlui` to automatically match profiles.
Basically, it will iterate over all saved profiles (sorted alphabetically), and it will apply the first profile where all currently connected monitors `uid` match.

This can also be used together with any script that listens for monitor changes, in order to apply the correct profile every time a monitor is connected/disconnected.
For instance, using [pyprland monitors](https://github.com/hyprland-community/pyprland/wiki/monitors), this should work, despite a little cumbersome:
```toml
[monitors.hotplug_commands]
# add all your monitors
"DELL P2417H CJFH277Q3HCB" = "wlrlui -m"
"Sony Something" = "wlrlui -m"
```